### PR TITLE
Ensure safe task execution and fix rendering issues

### DIFF
--- a/app/views/rails_execution/tasks/_attachment_files.html.haml
+++ b/app/views/rails_execution/tasks/_attachment_files.html.haml
@@ -1,3 +1,3 @@
 - if task_attachment_files.any?
   = re_card_content do
-    = render partial: 'attachments', locals: { task_attachment_files: }
+    = render partial: 'attachments', locals: { task_attachment_files: task_attachment_files }

--- a/app/views/rails_execution/tasks/_form.html.haml
+++ b/app/views/rails_execution/tasks/_form.html.haml
@@ -31,7 +31,7 @@
           = f.datetime_local_field :scheduled_at, class: "form-control", placeholder: "Select Datetime"
           = f.select :repeat_mode, options_for_select(task.repeat_mode_select_options.invert, f.object.repeat_mode), {}, class: "form-control", disabled: !task.scheduled_at?
         - if RailsExecution.configuration.file_upload
-          .mt-4= render partial: 'attachments', locals: { task_attachment_files: }
+          .mt-4= render partial: 'attachments', locals: { task_attachment_files: task_attachment_files }
           #attachment_files.mb-3
             %ul.list-unstyled= render partial: 'attachment_file_fields'
 

--- a/lib/rails_execution/services/execution.rb
+++ b/lib/rails_execution/services/execution.rb
@@ -44,6 +44,9 @@ module RailsExecution
           class #{class_name} < ::RailsExecution::Services::Executor
             def call
               task.with_lock do
+                stop!('Task is being executed by another process') if task.is_processing?
+
+                task.update!(status: :processing)
                 #{task.script}
               end
             end

--- a/lib/rails_execution/version.rb
+++ b/lib/rails_execution/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsExecution
-  VERSION = '0.1.8'
+  VERSION = '0.1.9'
 end


### PR DESCRIPTION
An update was brought in to ensure a safe environment for executing tasks. A new condition has been added that prevents a task from being run if it is already being processed by another function. By checking if the task is already in process before the execution starts, it prevents overlapping executions and potential data inconsistencies.

There was also a correction in rendering the partials for task attachments. Previously, these were being invoked without passing the required 'task_attachment_files' parameter, which led to failures in views involving task attachments. This parameter is now correctly transferred to the partials lifting the issue.

Lastly, the version number has been updated to '0.1.9', signaling these adjustments.